### PR TITLE
Use secure URI in Vcs-Git control header.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+blahtexml (0.9-2) UNRELEASED; urgency=medium
+
+  * Use secure URI in Vcs-Git/Vcs-Browser control header.
+
+ -- Jelmer Vernooĳ <jelmer@debian.org>  Wed, 12 Sep 2018 03:39:37 +0100
+
 blahtexml (0.9-1) unstable; urgency=low
 
   * New upstream version.

--- a/debian/control
+++ b/debian/control
@@ -5,8 +5,8 @@ Maintainer: Abhishek Dasgupta <abhidg@gmail.com>
 Build-Depends: debhelper (>= 7.0.50), libxerces-c-dev
 Standards-Version: 3.9.2
 Homepage: http://gva.noekeon.org/blahtexml/
-Vcs-Git: git://github.com/abhidg/pkg-blahtexml.git
-Vcs-Browser: http://github.com/abhidg/pkg-blahtexml
+Vcs-Git: https://github.com/abhidg/pkg-blahtexml.git
+Vcs-Browser: https://github.com/abhidg/pkg-blahtexml
 
 Package: blahtexml
 Architecture: any


### PR DESCRIPTION
Use secure URI in Vcs-Git control header.

Fixes lintian: vcs-field-uses-insecure-uri
See https://lintian.debian.org/tags/vcs-field-uses-insecure-uri.html for more details.
