### PR TITLE
Use correct machine-readable copyright file URI.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+blahtexml (0.9-2) UNRELEASED; urgency=medium
+
+  * Use correct machine-readable copyright file URI.
+
+ -- Jelmer Vernooĳ <jelmer@debian.org>  Wed, 12 Sep 2018 03:39:52 +0100
+
 blahtexml (0.9-1) unstable; urgency=low
 
   * New upstream version.

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,4 +1,4 @@
-Format-Specification: http://svn.debian.org/wsvn/dep/web/deps/dep5.mdwn?op=file&rev=135
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Name: Blahtexml
 Maintainer: Gilles Van Assche
 Source: http://gva.noekeon.org/blahtexml


### PR DESCRIPTION
Use correct machine-readable copyright file URI.

Fixes lintian: out-of-date-copyright-format-uri
See https://lintian.debian.org/tags/out-of-date-copyright-format-uri.html for more details.
